### PR TITLE
Make org worker zone-id as optional

### DIFF
--- a/cmd/autogenerated.go
+++ b/cmd/autogenerated.go
@@ -1986,7 +1986,6 @@ func init() {
 	}
 
 	UploadOrganizationWorker.Flags().StringVar(&ZoneId, "zone-id", "", "The zoneID associated with the worker")
-	UploadOrganizationWorker.MarkFlagRequired("zone-id")
 
 	UploadOrganizationWorker.Flags().StringVar(&OrganizationId, "organization-id", "", "The organization id associated with the worker")
 	UploadOrganizationWorker.MarkFlagRequired("organization-id")

--- a/definitions/definitions.toml
+++ b/definitions/definitions.toml
@@ -2479,7 +2479,7 @@
   name = "zone-id"
   type = "string"
   description = "The zoneID associated with the worker"
-  required = true
+  required = false
   [[command.option]]
   name = "organization-id"
   type = "string"


### PR DESCRIPTION
The organizational call to a worker does not require zoneid. The
reason for that is because customers want to be able to upload
a single worker to every zone in their organization.