### PR TITLE
Add support for workers kvs to cli

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -1237,6 +1238,63 @@ func GetUserAuditLogs(api *cloudflare.API, ActorIP string, ActorEmail string, Zo
 		PerPage:    PerPage,
 		Page:       Page,
 	})
+	return
+}
+
+func ListWorkersKVNamespaces(api *cloudflare.API, OrganizationId string) (resp interface{}, err error) {
+	resp, err = api.ListWorkersKVNamespaces(context.TODO())
+	return
+}
+
+func DeleteWorkersKVNamespace(api *cloudflare.API, OrganizationId string, NamespaceId string) (resp interface{}, err error) {
+	resp, err = api.DeleteWorkersKVNamespace(context.TODO(), NamespaceId)
+	return
+}
+
+func ListWorkersKVs(api *cloudflare.API, OrganizationId string, NamespaceId string) (resp interface{}, err error) {
+	resp, err = api.ListWorkersKVs(context.TODO(), NamespaceId)
+	return
+}
+
+func ReadWorkersKV(api *cloudflare.API, OrganizationId string, NamespaceId string, Key string) (resp interface{}, err error) {
+	resp, err = api.ReadWorkersKV(context.TODO(), NamespaceId, Key)
+	return
+}
+
+func DeleteWorkersKV(api *cloudflare.API, OrganizationId string, NamespaceId string, Key string) (resp interface{}, err error) {
+	resp, err = api.DeleteWorkersKV(context.TODO(), NamespaceId, Key)
+	return
+}
+
+func UpdateWorkersKVNamespace(api *cloudflare.API, OrganizationId string, NamespaceId string, Name string) (resp interface{}, err error) {
+	resp, err = api.UpdateWorkersKVNamespace(context.TODO(), NamespaceId, &cloudflare.WorkersKVNamespaceRequest{Title: Name})
+	return
+}
+
+func CreateWorkersKVNamespace(api *cloudflare.API, OrganizationId string, Name string) (resp interface{}, err error) {
+	resp, err = api.CreateWorkersKVNamespace(context.TODO(), &cloudflare.WorkersKVNamespaceRequest{Title: Name})
+	return
+}
+
+func WriteWorkersKV(api *cloudflare.API, OrganizationId string, NamespaceId string, Key string, Value string) (resp interface{}, err error) {
+	v := Value
+	if len(Value) != 0 {
+		if Value[0] == '@' {
+			valueFile := Value[1:]
+			fileValue, err := ioutil.ReadFile(valueFile)
+			if err != nil {
+				return resp, err
+			}
+			v = string(fileValue)
+		} else if Value == "-" {
+			fileValue, err := ioutil.ReadAll(os.Stdin)
+			if err != nil {
+				return resp, err
+			}
+			v = string(fileValue)
+		}
+	}
+	resp, err = api.WriteWorkersKV(context.TODO(), NamespaceId, Key, []byte(v))
 	return
 }
 

--- a/cmd/autogenerated.go
+++ b/cmd/autogenerated.go
@@ -101,6 +101,9 @@ var (
 	Direction           string
 	Before              string
 	Per_page            int
+	NamespaceId         string
+	Key                 string
+	Value               string
 )
 
 func init() {
@@ -2101,6 +2104,138 @@ func init() {
 
 	GetUserAuditLogs.Flags().IntVar(&Per_page, "per_page", 0, "How many results to return per page")
 
+	var ListKvNamespaces = &cobra.Command{
+		Use:   "list-kv-namespaces",
+		Short: "Get account's kv namespaces",
+		Long:  `Get your account's kv namespaces`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "ListWorkersKVNamespaces")
+		},
+	}
+
+	ListKvNamespaces.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	ListKvNamespaces.MarkFlagRequired("organization-id")
+
+	var DeleteKvNamespace = &cobra.Command{
+		Use:   "delete-kv-namespace",
+		Short: "Get account's kv namespaces",
+		Long:  `Get your account's kv namespaces`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "DeleteWorkersKVNamespace")
+		},
+	}
+
+	DeleteKvNamespace.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	DeleteKvNamespace.MarkFlagRequired("organization-id")
+
+	DeleteKvNamespace.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	DeleteKvNamespace.MarkFlagRequired("namespace-id")
+
+	var ListKvs = &cobra.Command{
+		Use:   "list-kvs",
+		Short: "List a specific namespaces keys",
+		Long:  `List a specific namespaces keys`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "ListWorkersKVs")
+		},
+	}
+
+	ListKvs.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	ListKvs.MarkFlagRequired("organization-id")
+
+	ListKvs.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	ListKvs.MarkFlagRequired("namespace-id")
+
+	var GetKv = &cobra.Command{
+		Use:   "get-kv",
+		Short: "Get a specific value given a key",
+		Long:  `Get a specific value given a key`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "ReadWorkersKV")
+		},
+	}
+
+	GetKv.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	GetKv.MarkFlagRequired("organization-id")
+
+	GetKv.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	GetKv.MarkFlagRequired("namespace-id")
+
+	GetKv.Flags().StringVar(&Key, "key", "", "The key associated with the value you want returned")
+	GetKv.MarkFlagRequired("key")
+
+	var DeleteKv = &cobra.Command{
+		Use:   "delete-kv",
+		Short: "Delete a specific key value pair",
+		Long:  `Delete a specific key value pair`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "DeleteWorkersKV")
+		},
+	}
+
+	DeleteKv.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	DeleteKv.MarkFlagRequired("organization-id")
+
+	DeleteKv.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	DeleteKv.MarkFlagRequired("namespace-id")
+
+	DeleteKv.Flags().StringVar(&Key, "key", "", "The key associated with the value you to deleted")
+	DeleteKv.MarkFlagRequired("key")
+
+	var WriteKv = &cobra.Command{
+		Use:   "write-kv",
+		Short: "Write a key value pair",
+		Long:  `Write a key value pair`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "WriteWorkersKV")
+		},
+	}
+
+	WriteKv.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	WriteKv.MarkFlagRequired("organization-id")
+
+	WriteKv.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	WriteKv.MarkFlagRequired("namespace-id")
+
+	WriteKv.Flags().StringVar(&Key, "key", "", "The key associated with the kv pair")
+	WriteKv.MarkFlagRequired("key")
+
+	WriteKv.Flags().StringVar(&Value, "value", "", "The value associated with the kv pair")
+	WriteKv.MarkFlagRequired("value")
+
+	var RenameKvNamespace = &cobra.Command{
+		Use:   "rename-kv-namespace",
+		Short: "Rename a kv namespace",
+		Long:  `Rename kv namespace`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "UpdateWorkersKVNamespace")
+		},
+	}
+
+	RenameKvNamespace.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	RenameKvNamespace.MarkFlagRequired("organization-id")
+
+	RenameKvNamespace.Flags().StringVar(&NamespaceId, "namespace-id", "", "The namespace id associated with the kv store")
+	RenameKvNamespace.MarkFlagRequired("namespace-id")
+
+	RenameKvNamespace.Flags().StringVar(&Name, "name", "", "The namespace's new name")
+	RenameKvNamespace.MarkFlagRequired("name")
+
+	var CreateKvNamespace = &cobra.Command{
+		Use:   "create-kv-namespace",
+		Short: "Create a kv namespace",
+		Long:  `Create a kv namespace`,
+		Run: func(cmd *cobra.Command, args []string) {
+			Main(cmd, args, "CreateWorkersKVNamespace")
+		},
+	}
+
+	CreateKvNamespace.Flags().StringVar(&OrganizationId, "organization-id", "", "The user's organization id")
+	CreateKvNamespace.MarkFlagRequired("organization-id")
+
+	CreateKvNamespace.Flags().StringVar(&Name, "name", "", "The namespace's name")
+	CreateKvNamespace.MarkFlagRequired("name")
+
 	var Zone = &cobra.Command{
 		Use:   "zone",
 		Short: "Interact with cloudflare zones",
@@ -2140,15 +2275,23 @@ func init() {
 `,
 	}
 	Worker.AddCommand(CreateWorkerRoute)
+	Worker.AddCommand(CreateKvNamespace)
+	Worker.AddCommand(DeleteKv)
+	Worker.AddCommand(DeleteKvNamespace)
 	Worker.AddCommand(DeleteOrganizationWorker)
 	Worker.AddCommand(DeleteWorker)
 	Worker.AddCommand(DownloadOrganizationWorker)
 	Worker.AddCommand(DownloadWorker)
+	Worker.AddCommand(GetKv)
+	Worker.AddCommand(ListKvs)
+	Worker.AddCommand(ListKvNamespaces)
 	Worker.AddCommand(ListWorkerRoutes)
 	Worker.AddCommand(ListWorkerScripts)
+	Worker.AddCommand(RenameKvNamespace)
 	Worker.AddCommand(UpdateWorkerRoute)
 	Worker.AddCommand(UploadOrganizationWorker)
 	Worker.AddCommand(UploadWorker)
+	Worker.AddCommand(WriteKv)
 
 	RootCmd.AddCommand(Worker)
 
@@ -2564,6 +2707,22 @@ func Run(cmd *cobra.Command, args []string, name string, api *cloudflare.API) (r
 		resp, err = GetOrganizationAuditLogs(api, OrganizationId)
 	case "GetUserAuditLogs":
 		resp, err = GetUserAuditLogs(api, ActorIp, ActorEmail, ZoneName, Since, Id, Direction, Before, Page, Per_page)
+	case "ListWorkersKVNamespaces":
+		resp, err = ListWorkersKVNamespaces(api, OrganizationId)
+	case "DeleteWorkersKVNamespace":
+		resp, err = DeleteWorkersKVNamespace(api, OrganizationId, NamespaceId)
+	case "ListWorkersKVs":
+		resp, err = ListWorkersKVs(api, OrganizationId, NamespaceId)
+	case "ReadWorkersKV":
+		resp, err = ReadWorkersKV(api, OrganizationId, NamespaceId, Key)
+	case "DeleteWorkersKV":
+		resp, err = DeleteWorkersKV(api, OrganizationId, NamespaceId, Key)
+	case "WriteWorkersKV":
+		resp, err = WriteWorkersKV(api, OrganizationId, NamespaceId, Key, Value)
+	case "UpdateWorkersKVNamespace":
+		resp, err = UpdateWorkersKVNamespace(api, OrganizationId, NamespaceId, Name)
+	case "CreateWorkersKVNamespace":
+		resp, err = CreateWorkersKVNamespace(api, OrganizationId, Name)
 	default:
 		break
 	}

--- a/definitions/definitions.toml
+++ b/definitions/definitions.toml
@@ -38,15 +38,23 @@
 """
   subcommands = [
     "create-worker-route",
+    "create-kv-namespace",
+    "delete-kv",
+    "delete-kv-namespace",
     "delete-organization-worker",
     "delete-worker",
     "download-organization-worker",
     "download-worker",
+    "get-kv",
+    "list-kvs",
+    "list-kv-namespaces",
     "list-worker-routes",
     "list-worker-scripts",
+    "rename-kv-namespace",
     "update-worker-route",
     "upload-organization-worker",
     "upload-worker",
+    "write-kv",
   ]
   toplevel = true
   shortdescription = "Interact with cloudflare workers api"
@@ -2622,3 +2630,151 @@
   type = "int"
   description = "How many results to return per page"
   required = false
+
+[[command]]
+  name = "list-kv-namespaces"
+  description = """Get your account's kv namespaces"""
+  shortdescription = "Get account's kv namespaces"
+  v4apiname = "ListWorkersKVNamespaces"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+
+[[command]]
+  name = "delete-kv-namespace"
+  description = """Get your account's kv namespaces"""
+  shortdescription = "Get account's kv namespaces"
+  v4apiname = "DeleteWorkersKVNamespace"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+
+[[command]]
+  name = "list-kvs"
+  description = """List a specific namespaces keys"""
+  shortdescription = "List a specific namespaces keys"
+  v4apiname = "ListWorkersKVs"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+
+[[command]]
+  name = "get-kv"
+  description = """Get a specific value given a key"""
+  shortdescription = "Get a specific value given a key"
+  v4apiname = "ReadWorkersKV"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+  [[command.option]]
+  name = "key"
+  type = "string"
+  description = "The key associated with the value you want returned"
+  required = true
+
+[[command]]
+  name = "delete-kv"
+  description = """Delete a specific key value pair"""
+  shortdescription = "Delete a specific key value pair"
+  v4apiname = "DeleteWorkersKV"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+  [[command.option]]
+  name = "key"
+  type = "string"
+  description = "The key associated with the value you to deleted"
+  required = true
+
+[[command]]
+  name = "write-kv"
+  description = """Write a key value pair"""
+  shortdescription = "Write a key value pair"
+  v4apiname = "WriteWorkersKV"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+  [[command.option]]
+  name = "key"
+  type = "string"
+  description = "The key associated with the kv pair"
+  required = true
+  [[command.option]]
+  name = "value"
+  type = "string"
+  description = "The value associated with the kv pair"
+  required = true
+
+[[command]]
+  name = "rename-kv-namespace"
+  description = """Rename kv namespace"""
+  shortdescription = "Rename a kv namespace"
+  v4apiname = "UpdateWorkersKVNamespace"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "namespace-id"
+  type = "string"
+  description = "The namespace id associated with the kv store"
+  required = true
+  [[command.option]]
+  name = "name"
+  type = "string"
+  description = "The namespace's new name"
+  required = true
+
+[[command]]
+  name = "create-kv-namespace"
+  description = """Create a kv namespace"""
+  shortdescription = "Create a kv namespace"
+  v4apiname = "CreateWorkersKVNamespace"
+  [[command.option]]
+  name = "organization-id"
+  type = "string"
+  description = "The user's organization id"
+  required = true
+  [[command.option]]
+  name = "name"
+  type = "string"
+  description = "The namespace's name"
+  required = true


### PR DESCRIPTION
This PR adds several subcommands to the workers subcommand. Let's describe how
each one works and what they do.

**ListWorkersKVNamespaces**:
ListWorkersKVNamespaces is implemented in the cf worker list-kv-namespaces.

It requires an organization id is passed in to it:
```
$ cf worker list-kv-namespaces --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
{
     "success": true,
     "errors": [],
     "messages": [],
     "result": [
         {
             "id": "28511bdf7bff4a9a977dd163078752b9",
             "title": "testnamespace"
         }
     ],
     "result_info": {
         "page": 1,
         "per_page": 20,
         "total_pages": 1,
         "count": 1,
         "total_count": 1
     }
 }

```

**CreateWorkersKVNamespace**:
Create a new workers kv namespace. Only requires org id and name.
```
$ cf worker create-kv-namespace --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --name testnamespace
{
     "success": true,
     "errors": [],
     "messages": [],
     "result": {
         "id": "28511bdf7bff4a9a977dd163078752b9",
         "title": "testnamespace"
     }
 }
 ```

**DeleteWorkersKVNamespace**:
DeleteWorkersKVNamespace is implemented in the cf worker delete-kv-namespace. Only requires org id and namespace id

It requires an organization id and namespace id are passed in:
```
$ cf worker list-kv-namespaces --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9
{
     "success": true,
     "errors": [],
     "messages": []
 }
```

**UpdateWorkersKVNamespace**:
Rename a workers kv namespace.
```
$ cf worker rename-kv-namespace --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --name newtestnamespace
{
     "success": true,
     "errors": [],
     "messages": []
}
```

**ListWorkersKVs**:
List the keys that are in a specific namespace.
```
$ cf worker list-kvs --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9
{
     "success": true,
     "errors": [],
     "messages": [],
     "result": [
         {
             "name": "testkey"
         }
     ],
     "result_info": {
         "page": 1,
         "per_page": 20,
         "total_pages": 1,
         "count": 1,
         "total_count": 1
     }
 }

```

**DeleteWorkersKV**
Use the cf worker delete-kv command. It requires org id, namespace id, and key.
```
$ cf worker delete-kv --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --key testkey
{
     "success": true,
     "errors": [],
     "messages": []
}
```

**ReadWorkersKV**:
Implemented in the cf worker get-kv command. It requires org id, namespace id, and key.

ReadWorkersKV returns the base64 encoded value.
```
$ cf worker get-kv --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --key testkey
"YWRkRXZlbnRMaXN0ZW5lcigiZmV0Y2giLCBldmVudCA9PiB7IAogIGV2ZW50LnJlc3BvbmRXaXRoKG5ldyBSZXNwb25zZSgiaGV5IikpCn0pCg=="
```

**WriteWorkersKV**
This is the most special command added, because of the value argument. The value
argument supports a few different formats.
    - _Read from stdin_: If you want cf to read value from stdin, pass a hyphen (-)
    - _Read from file_: If you want cf to read from a file pass the filename preceeded by an @ like in the example
    - _Raw_: By default, write-kv will just write whatever you pass to  the --value argument

The below example shows reading from a file.
```
$ cf worker write-kv --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --key testkey --value @examplefile.json
{
     "success": true,
     "errors": [],
     "messages": []
}
 ```

This is an example of reading from stdin.
```
$ cat examplefile.json | cf worker write-kv --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --key testkey --value -
{
     "success": true,
     "errors": [],
     "messages": []
}
 ```

This is an example of passing the raw value
```
cf worker write-kv --organization-id bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb --namespace-id 28511bdf7bff4a9a977dd163078752b9 --key testkey --value '{1:2}'
{
     "success": true,
     "errors": [],
     "messages": []
}
 ```